### PR TITLE
make JOLI optional for generality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.7.2"
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
-JOLI = "bb331ad6-a1cf-11e9-23da-9bcb53c69f6f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 Nullables = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"

--- a/src/Composite/funCompR1.jl
+++ b/src/Composite/funCompR1.jl
@@ -10,8 +10,7 @@ function funCompR1(A::TA,
                        r::AbstractArray,
                        funForward::Function, funPenalty::Function, 
                        nProdAt::Int64,
-                       params::Dict{String,Any}) where
-                         {TA<:Union{joAbstractLinearOperator,AbstractArray,Function}}
+                       params::Dict{String,Any}) where {TA<:InTypeF}
 
     nProdAt += one(Int64)
     f,v = funPenalty(r, params)

--- a/src/Composite/funCompR2.jl
+++ b/src/Composite/funCompR2.jl
@@ -10,8 +10,7 @@ function funCompR2(A::TA,
                        r::AbstractArray,
                        funForward::Function, funPenalty::Function, 
                        nProdAt::Int64,
-                       params::Dict{String,Any}) where
-                         {TA<:Union{joAbstractLinearOperator,AbstractArray,Function}}
+                       params::Dict{String,Any}) where {TA<:InType}
 
     nProdAt += one(Int64)
     f,v = funPenalty(r, params)

--- a/src/GenSPGL.jl
+++ b/src/GenSPGL.jl
@@ -10,7 +10,17 @@ using LinearAlgebra
 using MAT
 using JLD
 using Arpack
-using JOLI
+using Requires
+
+const InTypeF = Union{AbstractArray, Function}
+const InType = Union{AbstractArray}
+
+function __init__()
+    @require JOLI = "bb331ad6-a1cf-11e9-23da-9bcb53c69f6f"
+    @eval using JOLI
+    global const InTypeF = Union{joAbstractLinearOperator, AbstractArray, Function}
+    global const InType = Union{joAbstractLinearOperator, AbstractArray}
+end
 
 # Types
 include("spgOptions.jl")

--- a/src/spgInit.jl
+++ b/src/spgInit.jl
@@ -8,12 +8,8 @@ GenSPGL Initialized local vars composite type. \n
 Passed to spglcore.jl
 
 """
-mutable struct spgInit{TA<:Union{joAbstractLinearOperator,AbstractArray, Function},
-                                                ETb<:Number,
-                                                ETx<:Number,
-                                                ETg<:Number,
-                                                ETr<:Number,
-                                                Tidx<:BitArray}
+mutable struct spgInit{TA<:InTypeF, ETb<:Number, ETx<:Number,
+                       ETg<:Number, ETr<:Number, Tidx<:BitArray}
     
     A::TA
     b::AbstractVector{ETb}

--- a/src/spgl1.jl
+++ b/src/spgl1.jl
@@ -61,7 +61,7 @@ function spgl1(A::TA,
                sigma::AbstractFloat=NaN,
                options::spgOptions = spgOptions(),
                params::Dict{String,Any} = Dict{String,Any}()) where
-                 {TA<:Union{joAbstractLinearOperator,AbstractArray}, ETx<:Number, ETb<:Number}
+                 {TA<:InType, ETx<:Number, ETb<:Number}
     
     REVISION = "0.1"
     DATE = "June, 2017"
@@ -357,7 +357,7 @@ end
 Activated when an explicit or JOLI operator is passed in.
 """
 function SpotFunForward(A::TA, x::AbstractArray, g::AbstractArray, params::Dict) where
-                       {TA<:Union{joAbstractLinearOperator,AbstractArray}}
+                       {TA<:InType}
     #DEVNOTE# Double check type of g once in use
 
     isempty(g) && (f = A*x)

--- a/src/spglcore.jl
+++ b/src/spglcore.jl
@@ -26,7 +26,7 @@ export spglcore
     and Aleksandr Aravkin's MATLAB program SPGL1. 
 """
 function spglcore(init::spgInit{TA, ETb, ETx, ETg, ETr, Tidx}) where
-            {TA<:Union{joAbstractLinearOperator, AbstractArray, Function},
+            {TA<:InTypeF,
              ETb<:Number, ETx<:Number, ETg<:Number, ETr<:Number, Tidx<:BitArray}
 
     #DEVNOTE# Create spgInit type to hold all these initialized paramaters

--- a/src/spgline.jl
+++ b/src/spgline.jl
@@ -17,8 +17,7 @@ function spgline(A::TA,
                  linear::Bool,
                  options::spgOptions,
                  timeProject::Float64) where
-                   {TA<:Union{joAbstractLinearOperator, AbstractArray},
-                    Tf<:Number, ETx<:Number, ETb<:Number}
+                   {TA<:InType, Tf<:Number, ETx<:Number, ETb<:Number}
 
     (options.verbosity > 1) && println("Script entered spgline for A::Function")
 

--- a/src/spglinecurvy.jl
+++ b/src/spglinecurvy.jl
@@ -17,8 +17,7 @@ function spglinecurvy(A::TA,
                       tau::AbstractFloat,
                       options::spgOptions,
                       params::Dict{String,Any}) where
-                        {TA<:Union{joAbstractLinearOperator, AbstractArray},
-                         Tf<:Number, ETx<:Number, ETg<:Number, ETb<:Number}
+                        {TA<:InType, Tf<:Number, ETx<:Number, ETg<:Number, ETb<:Number}
 
     (options.verbosity > 1) && println("Script entered spglinecurvy for A::AbstractArray")
 


### PR DESCRIPTION
Make JOLI optional so that works with standard matrices without the need for JOLI.