### PR TITLE
single precision tweaks

### DIFF
--- a/src/spgInit.jl
+++ b/src/spgInit.jl
@@ -39,12 +39,12 @@ mutable struct spgInit{TA<:Union{joAbstractLinearOperator,AbstractArray, Functio
     nNewton::Int64
     printTau::Bool
     subspace::Bool
-    stepG::Float64
-    xNorm1::Vector{Float64}
-    rNorm2::Vector{Float64}
+    stepG::ETx
+    xNorm1::Vector{ETx}
+    rNorm2::Vector{ETb}
     lambda::Vector{Float64}
     lastFv::Vector{Float64} # Has to be Float64 to support Inf
-    gStep::Float64
+    gStep::ETx
     funForward::Function
     nLineTot::Int64
     nProdAt::Int64

--- a/src/spgl1.jl
+++ b/src/spgl1.jl
@@ -120,7 +120,7 @@ function spgl1(A::TA,
     nnzIter = zero(Int64) # No. of Its with fixed pattern
     nnzIdx = BitArray{1}()  # Active set indicator
     subspace = false        # Flag if did subspace min in current itn
-    stepG = 1.0               # Step length for projected gradient
+    stepG = ETx(1.0)               # Step length for projected gradient
     testUpdateTau = false
 
     ##-------------------------------------------------------------------------------
@@ -179,8 +179,8 @@ function spgl1(A::TA,
     #DEVNOTE# Once these are being updated check to see if type should be inferred
             # from promotion rules
     # Pre-Allocate iteration info vectors
-    xNorm1 = zeros(Float64, min(options.iterations,10000))
-    rNorm2 = zeros(Float64, min(options.iterations,10000))
+    xNorm1 = zeros(ETx, min(options.iterations,10000))
+    rNorm2 = zeros(ETb, min(options.iterations,10000))
     lambda = zeros(Float64, min(options.iterations,10000))
 
     # Create ExitCondition with null trigger
@@ -250,9 +250,9 @@ function spgl1(A::TA,
        
     dxNorm = norm(dx,Inf)
     if dxNorm < (1/options.stepMax)
-        gStep = options.stepMax
+        gStep = ETx(options.stepMax)
     else
-        gStep = min(options.stepMax, max(options.stepMin, 1/dxNorm))
+        gStep = ETx(min(options.stepMax, max(options.stepMin, 1/dxNorm)))
     end
 
     # Required for non-monotone strategy
@@ -441,7 +441,7 @@ function spgl1(A::Function, b::AbstractVector{ETb};
     nnzIter = zero(Int64) # No. of Its with fixed pattern
     nnzIdx = BitArray{1}()  # Active set indicator
     subspace = false        # Flag if did subspace min in current itn
-    stepG = 1.0               # Step length for projected gradient
+    stepG = ETx(1.0)               # Step length for projected gradient
     testUpdateTau = false
 
     ##-------------------------------------------------------------------------------
@@ -494,8 +494,8 @@ function spgl1(A::Function, b::AbstractVector{ETb};
     #DEVNOTE# Once these are being updated check to see if type should be inferred
             # from promotion rules
     # Pre-Allocate iteration info vectors
-    xNorm1 = zeros(Float64, min(options.iterations,10000))
-    rNorm2 = zeros(Float64, min(options.iterations,10000))
+    xNorm1 = zeros(ETx, min(options.iterations,10000))
+    rNorm2 = zeros(ETb, min(options.iterations,10000))
     lambda = zeros(Float64, min(options.iterations,10000))
 
     # Create ExitCondition with null trigger
@@ -565,9 +565,9 @@ function spgl1(A::Function, b::AbstractVector{ETb};
 
     dxNorm = norm(dx,Inf)
     if dxNorm < (1/options.stepMax)
-        gStep = options.stepMax
+        gStep = ETx(options.stepMax)
     else
-        gStep = min(options.stepMax, max(options.stepMin, 1/dxNorm))
+        gStep = ETx(min(options.stepMax, max(options.stepMin, 1/dxNorm)))
     end
 
     # Required for non-monotone strategy


### PR DESCRIPTION
Prevents `stepG * g` to convert `g` to double precision as `stepG` is always `Float64` currently.